### PR TITLE
Feature/notifications login

### DIFF
--- a/src/main/java/com/mycom/myapp/config/LoginAuthenticationSuccessHandler.java
+++ b/src/main/java/com/mycom/myapp/config/LoginAuthenticationSuccessHandler.java
@@ -2,19 +2,27 @@ package com.mycom.myapp.config;
 
 import java.io.IOException;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+
+import com.mycom.myapp.notifications.service.AlertService;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+import lombok.extern.slf4j.Slf4j;
 
 // Login 성공
 @Component
+@Slf4j
 public class LoginAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
 
+	@Autowired
+	private AlertService alertService;
+	
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
 			Authentication authentication) throws IOException, ServletException {
@@ -28,6 +36,12 @@ public class LoginAuthenticationSuccessHandler implements AuthenticationSuccessH
 		HttpSession session = request.getSession();
 		
 		session.setAttribute("userId", userDetails.getUserId());
+		
+		try {
+			alertService.sendUnsentNotifications(userId);
+		} catch (Exception e) {
+			log.error("알림 전 중 오류 발생: {}", e.getMessage(), e);
+		}
 		
 		String jsonStr = String.format("""
 					{

--- a/src/main/java/com/mycom/myapp/events/dao/EventDao.java
+++ b/src/main/java/com/mycom/myapp/events/dao/EventDao.java
@@ -49,5 +49,8 @@ public interface EventDao {
     void insertTimeline(TimelineDto timelineDto);
 
     // is_sent = false (알림 미수신)인 user_event 조회
-    List<UserEventDto> listUnsentUserEvent(Long userId);
+    List<UserEventDto> listUnsentUserEvent(@Param("userId") Long userId);
+    
+    // is_sent = false인 user_event를 true로 변경
+    void updateUnsentUserEvent(@Param("userId") Long userId, @Param("eventId") Long eventId);
 }

--- a/src/main/java/com/mycom/myapp/events/dao/EventDao.java
+++ b/src/main/java/com/mycom/myapp/events/dao/EventDao.java
@@ -1,12 +1,15 @@
 package com.mycom.myapp.events.dao;
 
+import java.time.LocalDate;
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
 import com.mycom.myapp.events.dto.EventDto;
 import com.mycom.myapp.events.dto.EventSummaryDto;
 import com.mycom.myapp.events.dto.TimelineDto;
-import java.time.LocalDate;
-import java.util.List;
-import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Param;
+import com.mycom.myapp.notifications.dto.UserEventDto;
 
 @Mapper
 public interface EventDao {
@@ -45,4 +48,6 @@ public interface EventDao {
     void checkEvent(@Param("eventId") Long eventId);
     void insertTimeline(TimelineDto timelineDto);
 
+    // is_sent = false (알림 미수신)인 user_event 조회
+    List<UserEventDto> listUnsentUserEvent();
 }

--- a/src/main/java/com/mycom/myapp/events/dao/EventDao.java
+++ b/src/main/java/com/mycom/myapp/events/dao/EventDao.java
@@ -49,5 +49,5 @@ public interface EventDao {
     void insertTimeline(TimelineDto timelineDto);
 
     // is_sent = false (알림 미수신)인 user_event 조회
-    List<UserEventDto> listUnsentUserEvent();
+    List<UserEventDto> listUnsentUserEvent(Long userId);
 }

--- a/src/main/java/com/mycom/myapp/notifications/dto/UserEventDto.java
+++ b/src/main/java/com/mycom/myapp/notifications/dto/UserEventDto.java
@@ -1,0 +1,14 @@
+package com.mycom.myapp.notifications.dto;
+
+import lombok.Data;
+
+@Data
+public class UserEventDto {
+	
+	private Long userId;
+	
+	private Long eventId;
+	
+	private Integer isSent;
+	
+}

--- a/src/main/java/com/mycom/myapp/notifications/service/AlertServiceImpl.java
+++ b/src/main/java/com/mycom/myapp/notifications/service/AlertServiceImpl.java
@@ -1,0 +1,63 @@
+package com.mycom.myapp.notifications.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.mycom.myapp.events.dao.EventDao;
+import com.mycom.myapp.events.dto.EventDto;
+import com.mycom.myapp.notifications.dto.NotificationDto;
+import com.mycom.myapp.notifications.dto.UserEventDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AlertServiceImpl implements AlertService {
+	
+	private final EventDao eventDao;
+	
+	private final SimpMessagingTemplate messagingTemplate;
+	
+	@Override
+	public void sendNotifications(Long userId, Long eventId, String title) {
+	
+	}
+
+	@Override
+	@Transactional
+	public void sendUnsentNotifications(Long userId) {
+		List<NotificationDto> notifications = new ArrayList<>();
+		
+		List<UserEventDto> userEvents = eventDao.listUnsentUserEvent(userId);
+		
+		for(UserEventDto userEvent : userEvents) {
+			EventDto eventDto = eventDao.detailEvent(userEvent.getEventId());
+			
+			Long ownerId = eventDto.getOwnerId();
+			String title = eventDto.getTitle();
+			
+			if(!Objects.equals(ownerId, userEvent.getUserId())) {
+				NotificationDto notificationDto = NotificationDto.builder()
+						.userId(userId)
+						.eventId(userEvent.getEventId())
+						.title(title)
+						.build();
+				
+				notifications.add(notificationDto);
+			}
+		}
+		
+		for(NotificationDto notification : notifications) {
+			messagingTemplate.convertAndSend("/topic/user/" + userId, notification);
+			
+			eventDao.updateUnsentUserEvent(notification.getUserId(), notification.getEventId());
+		}
+	}
+
+	
+}

--- a/src/main/resources/mapper/event-mapper.xml
+++ b/src/main/resources/mapper/event-mapper.xml
@@ -192,4 +192,12 @@
     	where is_sent = 0
     	  and user_id = #{userId}
     </select>
+    
+    <!--is_sent = false인 user_event를 -->
+    <update id="updateUnsentUserEvent">
+    	update user_event
+    	set is_sent = 1
+    	where user_id = #{userId}
+    	  and event_id = #{eventId}
+    </update>
 </mapper>

--- a/src/main/resources/mapper/event-mapper.xml
+++ b/src/main/resources/mapper/event-mapper.xml
@@ -184,4 +184,11 @@
             having max(ed.event_date) &lt; curdate()
         )
     </update>
+    
+    <!--is_sent = false (알림 미수신)인 user_event 조회-->
+    <select id="listUnsentUserEvent" resultType="com.mycom.myapp.notifications.dto.UserEventDto">
+    	select user_id as userId, event_id as eventId, is_sent as isSent
+    	from user_event
+    	where is_sent = 0;
+    </select>
 </mapper>

--- a/src/main/resources/mapper/event-mapper.xml
+++ b/src/main/resources/mapper/event-mapper.xml
@@ -189,6 +189,7 @@
     <select id="listUnsentUserEvent" resultType="com.mycom.myapp.notifications.dto.UserEventDto">
     	select user_id as userId, event_id as eventId, is_sent as isSent
     	from user_event
-    	where is_sent = 0;
+    	where is_sent = 0
+    	  and user_id = #{userId}
     </select>
 </mapper>

--- a/src/test/java/com/mycom/myapp/events/dao/UnsentUserEventListTest.java
+++ b/src/test/java/com/mycom/myapp/events/dao/UnsentUserEventListTest.java
@@ -56,4 +56,28 @@ public class UnsentUserEventListTest {
     	assertEquals(0, userEvents.get(0).getIsSent());
     	
     }
+    
+    @Test
+    void updateUnsentUserEvent_정상_동작() {
+    	// given
+    	Long userId = 1L;
+    	Long eventId = 100L;
+    	
+    	// when
+    	eventDao.updateUnsentUserEvent(userId, eventId);
+    	
+    	// then
+        Integer notSentCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM user_event WHERE user_id = ? AND is_sent = 0",
+                Integer.class,
+                userId);
+        
+        Integer sentCount = jdbcTemplate.queryForObject(
+        		"SELECT COUNT(*) FROM user_event WHERE user_id = ? AND is_sent = 1",
+        		Integer.class,
+        		userId);
+
+        assertEquals(0, notSentCount);
+        assertEquals(2, sentCount);
+    }
 }

--- a/src/test/java/com/mycom/myapp/events/dao/UnsentUserEventListTest.java
+++ b/src/test/java/com/mycom/myapp/events/dao/UnsentUserEventListTest.java
@@ -47,7 +47,7 @@ public class UnsentUserEventListTest {
     	Long userId = 1L;
     	
     	// when
-    	List<UserEventDto> userEvents = eventDao.listUnsentUserEvent();
+    	List<UserEventDto> userEvents = eventDao.listUnsentUserEvent(userId);
     	
     	// then
     	assertEquals(1, userEvents.size());

--- a/src/test/java/com/mycom/myapp/events/dao/UnsentUserEventListTest.java
+++ b/src/test/java/com/mycom/myapp/events/dao/UnsentUserEventListTest.java
@@ -1,0 +1,59 @@
+package com.mycom.myapp.events.dao;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.mycom.myapp.notifications.dto.UserEventDto;
+
+@SpringBootTest
+@Transactional
+public class UnsentUserEventListTest {
+	
+    @Autowired
+    private EventDao eventDao;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    public void setUp() {
+        // 기존 테스트 데이터 정리
+        jdbcTemplate.update("DELETE FROM schedule");
+        jdbcTemplate.update("DELETE FROM user_event");
+        jdbcTemplate.update("DELETE FROM event_date");
+        jdbcTemplate.update("DELETE FROM timeline");
+        jdbcTemplate.update("DELETE FROM event");
+
+        // 이벤트 데이터 추가
+        jdbcTemplate.update("INSERT INTO event (id, title, status) VALUES (?, ?, ?)", 100L, "테스트 이벤트1", "CHECKED");
+        jdbcTemplate.update("INSERT INTO event (id, title, status) VALUES (?, ?, ?)", 200L, "테스트 이벤트2", "UNCHECKED");
+
+        // 사용자-이벤트 매핑 데이터 추가 (기존 사용자 ID 사용)
+        jdbcTemplate.update("INSERT INTO user_event (id, user_id, event_id) VALUES (?, ?, ?)", 100L, 1L, 100L);
+        jdbcTemplate.update("INSERT INTO user_event (id, user_id, event_id, is_sent) VALUES (?, ?, ?, ?)", 200L, 1L, 200L, 1);
+    }
+    
+    @Test
+    void listUnsentUserEvent_정상_동작() {
+    	// given
+    	Long userId = 1L;
+    	
+    	// when
+    	List<UserEventDto> userEvents = eventDao.listUnsentUserEvent();
+    	
+    	// then
+    	assertEquals(1, userEvents.size());
+    	assertEquals(1L, userEvents.get(0).getUserId());
+    	assertEquals(100L, userEvents.get(0).getEventId());
+    	assertEquals(0, userEvents.get(0).getIsSent());
+    	
+    }
+}

--- a/src/test/java/com/mycom/myapp/notifications/service/SendUnsentNotificationsTest.java
+++ b/src/test/java/com/mycom/myapp/notifications/service/SendUnsentNotificationsTest.java
@@ -1,0 +1,153 @@
+package com.mycom.myapp.notifications.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import com.mycom.myapp.events.dao.EventDao;
+import com.mycom.myapp.events.dto.EventDto;
+import com.mycom.myapp.notifications.dto.NotificationDto;
+import com.mycom.myapp.notifications.dto.UserEventDto;
+
+public class SendUnsentNotificationsTest {
+
+    @Mock
+    private EventDao eventDao;
+    
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+    
+    @InjectMocks
+    private AlertServiceImpl alertService;
+    
+    private final Long TEST_USER_ID = 123L;
+    private final Long TEST_EVENT_ID = 456L;
+    private final Long TEST_OWNER_ID = 789L;
+    private final String TEST_EVENT_TITLE = "테스트 이벤트";
+    
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+    
+    @Test
+    void 미전송_알림이_없을때() {
+        // given
+        when(eventDao.listUnsentUserEvent(TEST_USER_ID)).thenReturn(Collections.emptyList());
+        
+        // when
+        alertService.sendUnsentNotifications(TEST_USER_ID);
+        
+        // then
+        verify(messagingTemplate, never()).convertAndSend(anyString(), any(NotificationDto.class));
+        verify(eventDao, never()).updateUnsentUserEvent(anyLong(), anyLong());
+    }
+    
+    @Test
+    void 미전송_알림_정상_전송() {
+        // given
+        UserEventDto userEvent1 = new UserEventDto();
+        userEvent1.setUserId(TEST_USER_ID);
+        userEvent1.setEventId(TEST_EVENT_ID);
+        
+        UserEventDto userEvent2 = new UserEventDto();
+        userEvent2.setUserId(TEST_USER_ID);
+        userEvent2.setEventId(TEST_EVENT_ID + 1);
+        
+        List<UserEventDto> userEvents = Arrays.asList(userEvent1, userEvent2);
+        
+        EventDto eventDto1 = new EventDto();
+        eventDto1.setEventId(TEST_EVENT_ID);
+        eventDto1.setOwnerId(TEST_OWNER_ID); // 이벤트 소유자는 다른 사용자
+        eventDto1.setTitle(TEST_EVENT_TITLE);
+        
+        EventDto eventDto2 = new EventDto();
+        eventDto2.setEventId(TEST_EVENT_ID + 1);
+        eventDto2.setOwnerId(TEST_OWNER_ID);
+        eventDto2.setTitle(TEST_EVENT_TITLE + "2");
+        
+        when(eventDao.listUnsentUserEvent(TEST_USER_ID)).thenReturn(userEvents);
+        when(eventDao.detailEvent(TEST_EVENT_ID)).thenReturn(eventDto1);
+        when(eventDao.detailEvent(TEST_EVENT_ID + 1)).thenReturn(eventDto2);
+        
+        // when
+        alertService.sendUnsentNotifications(TEST_USER_ID);
+        
+        // then
+        verify(messagingTemplate, times(2)).convertAndSend(eq("/topic/user/" + TEST_USER_ID), 
+                any(NotificationDto.class));
+        
+        verify(eventDao).updateUnsentUserEvent(TEST_USER_ID, TEST_EVENT_ID);
+        verify(eventDao).updateUnsentUserEvent(TEST_USER_ID, TEST_EVENT_ID + 1);
+    }
+    
+    @Test
+    void 이벤트_소유자에게는_알림_전송_안함() {
+        // given
+        UserEventDto userEvent = new UserEventDto();
+        userEvent.setUserId(TEST_USER_ID);
+        userEvent.setEventId(TEST_EVENT_ID);
+        
+        List<UserEventDto> userEvents = Collections.singletonList(userEvent);
+        
+        EventDto eventDto = new EventDto();
+        eventDto.setEventId(TEST_EVENT_ID);
+        eventDto.setOwnerId(TEST_USER_ID); // 이벤트 소유자와 현재 사용자가 동일
+        eventDto.setTitle(TEST_EVENT_TITLE);
+        
+        when(eventDao.listUnsentUserEvent(TEST_USER_ID)).thenReturn(userEvents);
+        when(eventDao.detailEvent(TEST_EVENT_ID)).thenReturn(eventDto);
+        
+        alertService.sendUnsentNotifications(TEST_USER_ID);
+        
+        // then
+        verify(messagingTemplate, never()).convertAndSend(anyString(), any(NotificationDto.class));
+        verify(eventDao, never()).updateUnsentUserEvent(anyLong(), anyLong());
+    }
+    
+    @Test
+    void 알림_전송_중_예외_발생시_처리() {
+        // given
+        UserEventDto userEvent = new UserEventDto();
+        userEvent.setUserId(TEST_USER_ID);
+        userEvent.setEventId(TEST_EVENT_ID);
+        
+        List<UserEventDto> userEvents = Collections.singletonList(userEvent);
+        
+        EventDto eventDto = new EventDto();
+        eventDto.setEventId(TEST_EVENT_ID);
+        eventDto.setOwnerId(TEST_OWNER_ID);
+        eventDto.setTitle(TEST_EVENT_TITLE);
+        
+        when(eventDao.listUnsentUserEvent(TEST_USER_ID)).thenReturn(userEvents);
+        when(eventDao.detailEvent(TEST_EVENT_ID)).thenReturn(eventDto);
+        doThrow(new RuntimeException("WebSocket 전송 오류"))
+        .when(messagingTemplate).convertAndSend(anyString(), any(NotificationDto.class));
+
+        
+        try {
+            alertService.sendUnsentNotifications(TEST_USER_ID);
+            org.junit.jupiter.api.Assertions.fail("예외가 발생해야 합니다");
+        } catch (RuntimeException e) {
+            verify(eventDao, never()).updateUnsentUserEvent(anyLong(), anyLong());
+        }
+    }
+    
+}


### PR DESCRIPTION
### 로그인 시, WebSocket을 이용해 미수신 알림 제공 기능 구현
- 로그인 시, 사용자 ID를 받아와 user_event 테이블의 is_sent = 0인 항목 is_sent = 1로 변경 후, 초대된 이벤트에 대한 알림 송신 기능
- 이벤트 생성자는 알림을 받지 않도록 구현
- DAO Layer, Service Layer, AuthenticationHandler의 추가된 메소드에 대한 테스트 완료